### PR TITLE
Update docker-compose.yml

### DIFF
--- a/plantUml/docker-compose.yml
+++ b/plantUml/docker-compose.yml
@@ -32,5 +32,6 @@ services:
     environment:
       - PLANTUML_URL=http://plantuml-server:8080/
       - EXPORT_URL=http://image-export:8000/
+      - DRAWIO_SELF_CONTAINED=true
 networks:
   drawionet:


### PR DESCRIPTION
PlantUML does not appear to work unless this variable is set

I was unable to get PlantUML to work correctly w/out setting this flag which I saw was being referenced in the docker entrypoint


Without this flag we get this:
![image](https://user-images.githubusercontent.com/6491743/224188755-a6002473-9cf9-4ac5-b387-6d4cfcefd642.png)
![image](https://user-images.githubusercontent.com/6491743/224188764-ff455d07-7e8a-4573-9c88-e16c2e204938.png)

With the flag set:

![image](https://user-images.githubusercontent.com/6491743/224188813-cc399b17-2175-4cef-a8cf-19dfae12bb95.png)
![image](https://user-images.githubusercontent.com/6491743/224188823-e1320b6a-c698-4771-9fe2-ec632234372c.png)
